### PR TITLE
superset/import_dashboards.html: Update title, clean up html

### DIFF
--- a/superset/templates/superset/import_dashboards.html
+++ b/superset/templates/superset/import_dashboards.html
@@ -8,22 +8,24 @@
   {% endwith %}
 {% endblock %}
 
-{% block title %}{{ _("Import") }}{% endblock %}
+{% block title %}{{ _("Import dashboards") }}{% endblock %}
+
 {% block body %}
-    {% include "superset/flash_wrapper.html" %}
-    <div class="container">
-        <title>Import the dashboards.</title>
-        <h1>Import the dashboards.</h1>
-        <form method=post enctype=multipart/form-data>
-          <input
-            type="hidden"
-            name="csrf_token"
-            id="csrf_token"
-            value="{{ csrf_token() if csrf_token else '' }}"
-          >
-          <p><input type=file name=file>
-             <input type=submit value=Upload>
-          </p>
-        </form>
-    </div>
+  {% include "superset/flash_wrapper.html" %}
+
+  <div class="container">
+    <h1>Import dashboards</h1>
+
+    <form method="post" enctype="multipart/form-data">
+      <input
+      type="hidden"
+      name="csrf_token"
+      id="csrf_token"
+      value="{{ csrf_token() if csrf_token else '' }}" />
+      <p>
+        <input type="file" name="file" />
+        <input type="submit" value="Upload" class="btn" />
+      </p>
+    </form>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Soley a front-end/template change.

* Changes "Import the dashboards." to "Import dashboards"
* Cleans up the HTML to add quotes, self close tags, etc.
* Adds a class to the `<submit>` button to utilize bootstrap style
* Remove the `<title>` tag in body as it's not vaild HTML and redundant with `{% block %}`